### PR TITLE
Remove delay as a trait

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
-
+nrf52840-hal = "0.12.0"
 defmt = "0.2.0"
 defmt-rtt = "0.2.0"
 panic-probe = { version = "0.2.0", features = ["print-defmt"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,22 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
+
+defmt = "0.2.0"
+defmt-rtt = "0.2.0"
+panic-probe = { version = "0.2.0", features = ["print-defmt"] }
+
+[features]
+# set logging levels here
+default = [
+  "defmt-default",
+  # "dependency-a/defmt-trace",
+]
+
+# do NOT modify these features
+defmt-default = []
+defmt-trace = []
+defmt-debug = []
+defmt-info = []
+defmt-warn = []
+defmt-error = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 
 [dependencies]
 embedded-hal = "0.2.3"
-nrf52840-hal = "0.12.0"
+nrf52840-hal = "0.12.2"
 defmt = "0.2.0"
 defmt-rtt = "0.2.0"
 panic-probe = { version = "0.2.0", features = ["print-defmt"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,15 +5,14 @@
 #![no_std]
 
 use ehal::blocking::{
-    delay::DelayUs,
+    // delay::DelayUs,
     i2c::{Read, Write},
 };
 use embedded_hal as ehal;
 
 // TODO: Some kind of shared-bus thing for sharing i2c?
-pub struct SeeSaw<I2C, DELAY> {
+pub struct SeeSaw<I2C> {
     pub i2c: I2C,
-    pub delay: DELAY,
     pub address: u8,
 }
 
@@ -34,10 +33,10 @@ const BUFFER_MAX: usize = 32;
 const PAYLOAD_MAX: usize = BUFFER_MAX - 2;
 const DEFAULT_DELAY_US: u32 = 125;
 
-impl<I2C, DELAY> SeeSaw<I2C, DELAY>
+impl<I2C> SeeSaw<I2C>
 where
     I2C: Read + Write,
-    DELAY: DelayUs<u32>,
+    // DELAY: DelayUs<u32>,
 {
     fn write(&mut self, base: u8, function: u8, buf: &[u8]) -> Result<(), Error> {
         if buf.len() > PAYLOAD_MAX {
@@ -57,9 +56,9 @@ where
             .map_err(|_| Error::I2c)
     }
 
-    fn read(&mut self, base: u8, function: u8, delay_us: u32, buf: &mut [u8]) -> Result<(), Error> {
+    fn read(&mut self, base: u8, function: u8, buf: &mut [u8]) -> Result<(), Error> {
         self.write(base, function, &[])?;
-        self.delay.delay_us(delay_us);
+        // self.delay.delay_us(delay_us);
         self.i2c.read(self.address, buf).map_err(|_| Error::I2c)
     }
 
@@ -69,7 +68,7 @@ where
         self.read(
             keypad::BASE,
             keypad::functions::COUNT,
-            500,
+            // 500,
             &mut buf,
         )?;
         Ok(buf[0])
@@ -106,7 +105,8 @@ where
     ///
     /// Additionally theres some shenanigans to convert the raw bufer to (key + event)
     pub fn keypad_read_raw(&mut self, buf: &mut [u8]) -> Result<(), Error> {
-        self.read(keypad::BASE, keypad::functions::FIFO, 1000, buf)
+        // self.read(keypad::BASE, keypad::functions::FIFO, 1000, buf)
+        self.read(keypad::BASE, keypad::functions::FIFO, buf)
     }
 
     pub fn neopixel_set_pin(&mut self, pin: u8) -> Result<(), Error> {
@@ -172,21 +172,21 @@ where
 
     pub fn status_get_hwid(&mut self) -> Result<u8, Error> {
         let mut buf = [0u8; 1];
-        self.read(status::BASE, status::functions::HW_ID, DEFAULT_DELAY_US, &mut buf)
+        self.read(status::BASE, status::functions::HW_ID, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(buf[0])
     }
 
     pub fn status_get_version(&mut self) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
-        self.read(status::BASE, status::functions::VERSION, DEFAULT_DELAY_US, &mut buf)
+        self.read(status::BASE, status::functions::VERSION, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
     }
 
     pub fn status_get_options(&mut self) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
-        self.read(status::BASE, status::functions::OPTIONS, DEFAULT_DELAY_US, &mut buf)
+        self.read(status::BASE, status::functions::OPTIONS, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
     }
@@ -194,14 +194,15 @@ where
     // Get raw temperature. To convert to celcius, divide by (1 << 16)
     pub fn status_get_temp_raw(&mut self) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
-        self.read(status::BASE, status::functions::TEMP, 1000, &mut buf)
+        // self.read(status::BASE, status::functions::TEMP, 1000, &mut buf)
+        self.read(status::BASE, status::functions::TEMP, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
     }
 
-    pub fn delay_us(&mut self, us: u32) {
-        self.delay.delay_us(us);
-    }
+    // pub fn delay_us(&mut self, us: u32) {
+    //     self.delay.delay_us(us);
+    // }
 }
 
 pub mod status {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! Totally untested so far
 
 #![no_std]
-use defmt::Format; // <- derive attribute
+// use defmt::Format; // <- derive attribute
 
 use ehal::blocking::{
     // delay::DelayUs,
@@ -17,13 +17,13 @@ pub struct SeeSaw<I2C> {
     pub address: u8,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Format)]
 pub enum Error {
     I2c,
     SeeSaw(SeeSawError),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Format)]
 pub enum SeeSawError {
     SizeError,
     InvalidArgument,
@@ -41,6 +41,7 @@ where
 {
     fn write(&mut self, base: u8, function: u8, buf: &[u8]) -> Result<(), Error> {
         if buf.len() > PAYLOAD_MAX {
+            defmt::info!("payload max!");
             return Err(Error::SeeSaw(SeeSawError::SizeError));
         }
 
@@ -60,7 +61,9 @@ where
     fn read(&mut self, base: u8, function: u8, buf: &mut [u8]) -> Result<(), Error> {
         self.write(base, function, &[])?;
         // self.delay.delay_us(delay_us);
-        self.i2c.read(self.address, buf).map_err(|_| Error::I2c)
+        let bla = self.i2c.read(self.address, buf).map_err(|_| Error::I2c);
+        defmt::info!("error: {}", bla );
+        bla
     }
 
     /// Get the count of pending key events on the keypad
@@ -254,6 +257,7 @@ pub mod neopixel {
     }
 }
 
+#[macro_use] extern crate defmt;
 pub mod keypad {
     pub const BASE: u8 = 0x10;
 
@@ -266,14 +270,13 @@ pub mod keypad {
         pub const FIFO: u8 = 0x10;
     }
 
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    #[derive(Format)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Format)]
     pub struct KeyEvent {
         pub key: u8,
         pub event: Edge,
     }
 
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[derive(Debug, Copy, Clone, PartialEq, Eq, Format)]
     #[repr(u8)]
     pub enum Edge {
         /// Indicates that the key is currently pressed

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,6 @@ use ehal::blocking::{
     i2c::{Read, Write},
 };
 use embedded_hal as ehal;
-use nrf52840_hal::Timer;
 
 pub struct SeeSaw<I2C> {
     pub i2c: I2C,
@@ -29,7 +28,6 @@ pub enum SeeSawError {
 
 const BUFFER_MAX: usize = 32;
 const PAYLOAD_MAX: usize = BUFFER_MAX - 2;
-const DEFAULT_DELAY_US: u32 = 125;
 
 impl<I2C> SeeSaw<I2C>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,6 @@
 //! Driver for the Adafruit Seesaw.
-//!
-//! Totally untested so far
 
 #![no_std]
-// use defmt::Format; // <- derive attribute
 
 use ehal::blocking::{
     delay::DelayUs,
@@ -12,7 +9,6 @@ use ehal::blocking::{
 use embedded_hal as ehal;
 use nrf52840_hal::Timer;
 
-// TODO: Some kind of shared-bus thing for sharing i2c?
 pub struct SeeSaw<I2C> {
     pub i2c: I2C,
     pub address: u8,
@@ -38,7 +34,7 @@ const DEFAULT_DELAY_US: u32 = 125;
 impl<I2C> SeeSaw<I2C>
 where
     I2C: Read + Write,
-    // DELAY: Timer<u32>,
+
 {
     fn write(&mut self, base: u8, function: u8, buf: &[u8]) -> Result<(), Error> {
         if buf.len() > PAYLOAD_MAX {
@@ -61,10 +57,8 @@ where
 
     fn read<DELAY: DelayUs<u32>>(&mut self, base: u8, function: u8, delay: &mut DELAY, buf: &mut [u8]) -> Result<(), Error> {
         self.write(base, function, &[])?;
-        delay.delay_us(14000); //timer??
-        let bla = self.i2c.read(self.address, buf).map_err(|_| Error::I2c);
-        // defmt::info!("error: {}", bla );
-        bla
+        delay.delay_us(14000);
+        self.i2c.read(self.address, buf).map_err(|_| Error::I2c)
     }
 
     /// Get the count of pending key events on the keypad
@@ -111,7 +105,6 @@ where
     /// Additionally theres some shenanigans to convert the raw bufer to (key + event)
     pub fn keypad_read_raw<DELAY: DelayUs<u32>>(&mut self, buf: &mut [u8], delay: &mut DELAY) -> Result<(), Error> {
         self.read(keypad::BASE, keypad::functions::FIFO, delay, buf)
-        // self.read(keypad::BASE, keypad::functions::FIFO, buf)
     }
 
     pub fn neopixel_set_pin(&mut self, pin: u8) -> Result<(), Error> {
@@ -177,7 +170,6 @@ where
 
     pub fn status_get_hwid<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u8, Error> {
         let mut buf = [0u8; 1];
-        // self.read(status::BASE, status::functions::HW_ID, &mut buf)
         self.read(status::BASE, status::functions::HW_ID, delay, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(buf[0])
@@ -185,7 +177,6 @@ where
 
     pub fn status_get_version<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
-        // self.read(status::BASE, status::functions::VERSION, &mut buf)
         self.read(status::BASE, status::functions::VERSION, delay, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
@@ -193,7 +184,6 @@ where
 
     pub fn status_get_options<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
-        // self.read(status::BASE, status::functions::OPTIONS, &mut buf)
         self.read(status::BASE, status::functions::OPTIONS, delay, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
@@ -203,16 +193,9 @@ where
     pub fn status_get_temp_raw<DELAY: DelayUs<u32>>(&mut self, delay: &mut DELAY) -> Result<u32, Error> {
         let mut buf = [0u8; 4];
         self.read(status::BASE, status::functions::TEMP, delay, &mut buf)
-        // self.read(status::BASE, status::functions::TEMP, &mut buf)
             .map_err(|_| Error::I2c)?;
         Ok(u32::from_be_bytes(buf))
     }
-
-    // das muss irgendwie anders
-    // pub fn delay_us(&mut self, us: u32) {
-    //     // was muss hier hin???
-    //     delay.delay.delay_us(us);
-    // }
 }
 
 pub mod status {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@
 //! Totally untested so far
 
 #![no_std]
+use defmt::Format; // <- derive attribute
 
 use ehal::blocking::{
     // delay::DelayUs,
@@ -266,6 +267,7 @@ pub mod keypad {
     }
 
     #[derive(Debug, Copy, Clone, PartialEq, Eq)]
+    #[derive(Format)]
     pub struct KeyEvent {
         pub key: u8,
         pub event: Edge,


### PR DESCRIPTION
Removes delay as a trait so shared-bus crate can get used.
This is preparation for the [knurling sessions minesweeper game](https://knurling-books.ferrous-systems.com/neotrellis/neotrellis.html).
3 PRs belong together. Merge in this order:
- [x] this one first
- [ ] https://github.com/ferrous-systems/adafruit-neotrellis/pull/1
- [ ] https://github.com/knurling-rs/neotrellis-driver/pull/1